### PR TITLE
chore: Update Nushell to v0.100

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -65,7 +65,7 @@ runs:
     - name: Setup Nu
       uses: hustcer/setup-nu@v3
       with:
-        version: '0.99.0'
+        version: '0.100.0'
         enable-plugins: nu_plugin_query
 
     - name: Set Milestone


### PR DESCRIPTION
chore: Update Nushell to v0.100, closes #105 