### PR TITLE
deps: Upgrade Nushell to v0.102

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -65,7 +65,7 @@ runs:
     - name: Setup Nu
       uses: hustcer/setup-nu@v3
       with:
-        version: '0.101.0'
+        version: '0.102.0'
         enable-plugins: nu_plugin_query
 
     - name: Set Milestone


### PR DESCRIPTION
deps: Upgrade Nushell to v0.102, fixes #112 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Upgraded a core dependency to the latest version, enhancing compatibility and maintaining a smoother overall experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->