### PR TITLE
deps: Upgrade Nu to 0.106 and pin hustcer/setup-nu to v3.20

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -63,9 +63,9 @@ runs:
   using: 'composite'
   steps:
     - name: Setup Nu
-      uses: hustcer/setup-nu@v3.19
+      uses: hustcer/setup-nu@v3.20
       with:
-        version: '0.105.0'
+        version: '0.106.0'
         enable-plugins: nu_plugin_query
 
     - name: Set Milestone

--- a/nu/common.nu
+++ b/nu/common.nu
@@ -45,7 +45,7 @@ export def get-env [
   key: string,       # The key to get it's env value
   default?: string,  # The default value for an empty env
 ] {
-  $env | get -i $key | default $default
+  $env | get -o $key | default $default
 }
 
 # Check if a git repo has the specified ref: could be a branch or tag, etc.
@@ -74,8 +74,8 @@ export def compare-ver [v1: string, v2: string] {
   # If you want to compare more parts use the following code:
   # for i in 0..([2 ($a | length) ($b | length)] | math max)
   for i in 0..2 {
-    let x = $a | get -i $i | default 0
-    let y = $b | get -i $i | default 0
+    let x = $a | get -o $i | default 0
+    let y = $b | get -o $i | default 0
     if $x > $y { return 1    }
     if $x < $y { return (-1) }
   }


### PR DESCRIPTION
deps: Upgrade Nu to 0.106 and pin hustcer/setup-nu to v3.20

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Action to use the latest version of the setup tool and Nu version.

* **Refactor**
  * Improved environment variable and version comparison handling for more robust value retrieval.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->