### PR TITLE
ci skip

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,3 +122,4 @@ Yes, you can set `inherit-from-issue: false` in the action inputs to disable thi
 Licensed under:
 
 - MIT license ([LICENSE](LICENSE) or http://opensource.org/licenses/MIT)
+


### PR DESCRIPTION
Fixes #127, #131 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved README formatting by adding a blank line after the MIT license line for clearer separation and better readability.
  * Enhances Markdown rendering consistency across platforms (e.g., GitHub, editors, and site generators).
  * No changes to features, behavior, or APIs.
  * No build or runtime impact; no user action required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->