### PR TITLE
fix: Fall back to the earliest-created milestone if no due_on set for milestones

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,3 +121,4 @@ Yes, you can set `inherit-from-issue: false` in the action inputs to disable thi
 Licensed under:
 
 - MIT license ([LICENSE](LICENSE) or http://opensource.org/licenses/MIT)
+

--- a/nu/milestone.nu
+++ b/nu/milestone.nu
@@ -173,7 +173,7 @@ export def guess-milestone-for-pr [
   if false { hr-line -c grey66; $guess | print; hr-line -c grey66 }
   let milestone = if ($guess | is-empty) {
     print 'No milestone found due after the PR merged. Fall back to the earliest-created milestone.'
-    $milestones | sort-by -r due_on | sort-by created_at | first
+    $milestones | sort-by due_on created_at | first
   } else { $guess | first }
   $milestone.title
 }

--- a/nu/milestone.nu
+++ b/nu/milestone.nu
@@ -172,8 +172,8 @@ export def guess-milestone-for-pr [
   let guess = $milestones | where due_on >= $mergedAt | sort-by due_on
   if false { hr-line -c grey66; $guess | print; hr-line -c grey66 }
   let milestone = if ($guess | is-empty) {
-    print 'No milestone found due after the PR merged. Fall back to the latest milestone.'
-    $milestones | sort-by -r due_on created_at | first
+    print 'No milestone found due after the PR merged. Fall back to the earliest-created milestone.'
+    $milestones | sort-by -r due_on | sort-by created_at | first
   } else { $guess | first }
   $milestone.title
 }


### PR DESCRIPTION
Fixes #144 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a trailing blank line after the MIT license in the README to ensure consistent rendering.

* **Bug Fixes**
  * Changed milestone fallback behavior: when no milestone matches a PR date, the earliest-created milestone is now chosen instead of the latest, affecting selection in edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->