### PR TITLE
fix: Fix some typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,4 +121,3 @@ Yes, you can set `inherit-from-issue: false` in the action inputs to disable thi
 Licensed under:
 
 - MIT license ([LICENSE](LICENSE) or http://opensource.org/licenses/MIT)
-

--- a/nu/milestone.nu
+++ b/nu/milestone.nu
@@ -172,7 +172,7 @@ export def guess-milestone-for-pr [
   let guess = $milestones | where due_on >= $mergedAt | sort-by due_on
   if false { hr-line -c grey66; $guess | print; hr-line -c grey66 }
   let milestone = if ($guess | is-empty) {
-    print 'No milestone found due after the PR merged. Fall back to the earliest-created milestone.'
+    print 'No milestone found due after the PR merged. Falling back to the earliest-created milestone.'
     $milestones | sort-by created_at | first
   } else { $guess | first }
   $milestone.title

--- a/nu/query.nu
+++ b/nu/query.nu
@@ -51,7 +51,7 @@ def query-issue-status [issueNO: int, payload: string, token: string] {
   # Loop 5 times to find the milestone of the last closed PR
   loop {
     if $milestone != '-' or $tries > 5 { break }
-    print $'Try to query milestone for issue (ansi p)($issueNO)(ansi reset) the (ansi p)($tries)(ansi reset) time ...'
+    print $'Try to query milestone for issue (ansi p)($issueNO)(ansi reset) the (ansi p)($tries)(ansi reset) (if $tries == 1 { "time" } else { "times" }) ...'
     $result = (http post --content-type application/json -H $HEADERS $QUERY_API $payload
       | get data.repository.issueOrPullRequest)
 


### PR DESCRIPTION
fixes #150 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Removed an extraneous bullet in README’s License section.
- Bug Fixes
  - Corrected pluralization in status output to display “time” vs. “times” appropriately.
- Style
  - Improved fallback log message wording for milestone detection to be clearer (“Falling back to the earliest-created milestone.”).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->