### PR TITLE
chore: Sort milestones by due date, then creation time

### DIFF
--- a/nu/milestone.nu
+++ b/nu/milestone.nu
@@ -169,7 +169,7 @@ export def guess-milestone-for-pr [
   let mergedAt = try {
     gh pr view $pr --repo $repo --json 'mergedAt' | from json | get mergedAt | into datetime
   } catch { (date now | into datetime) }
-  let guess = $milestones | where due_on >= $mergedAt | sort-by due_on
+  let guess = $milestones | where due_on >= $mergedAt | sort-by due_on created_at
   if false { hr-line -c grey66; $guess | print; hr-line -c grey66 }
   let milestone = if ($guess | is-empty) {
     print 'No milestone found due after the PR merged. Falling back to the earliest-created milestone.'


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved automatic milestone assignment for pull requests by adding creation date as a tiebreaker when multiple milestones share the same due date. This results in more consistent and predictable selections, favoring earlier-created milestones in ties. The fallback remains unchanged, selecting the earliest-created milestone when no suitable due date match is found.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->