### PR TITLE
deps: Upgrade Nushell to v0.108.0

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -69,7 +69,7 @@ runs:
     - name: Setup Nu
       uses: hustcer/setup-nu@v3.20
       with:
-        version: '0.107.0'
+        version: '0.108.0'
         enable-plugins: nu_plugin_query
 
     - name: Set Milestone


### PR DESCRIPTION
deps: Upgrade Nushell to v0.108.0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build tooling to the latest version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->