### PR TITLE
deps: Upgrade hustcer/setup-nu to v3.21

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -67,7 +67,7 @@ runs:
   using: 'composite'
   steps:
     - name: Setup Nu
-      uses: hustcer/setup-nu@v3.20
+      uses: hustcer/setup-nu@v3.21
       with:
         version: '0.108.0'
         enable-plugins: nu_plugin_query


### PR DESCRIPTION
deps: Upgrade hustcer/setup-nu to v3.21

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build infrastructure dependencies with an incremental patch version bump.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->