### PR TITLE
fix: Harden action inputs and make GraphQL file lookup path-independent

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 # Description:
 #   - Create, Close and Delete a milestone.
 
-name: Milestone Operations@develop
+name: Milestone Operations@local
 on:
   pull_request:
   workflow_dispatch:
@@ -15,9 +15,14 @@ jobs:
     runs-on: ubuntu-latest
     name: Milestone Operates
     steps:
+      # Required by `uses: ./`, so that CI exercises the code under review
+      # instead of the published action from a remote branch.
+      - name: Checkout
+        uses: actions/checkout@v7
+
       - name: Create Milestone
         id: create
-        uses: hustcer/milestone-action@develop
+        uses: ./
         with:
           action: create
           title: 'v0.0.1'
@@ -27,7 +32,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Close Milestone
         id: close
-        uses: hustcer/milestone-action@develop
+        uses: ./
         with:
           action: close
           milestone: 'v0.0.1'
@@ -35,7 +40,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Delete Milestone
         id: delete
-        uses: hustcer/milestone-action@develop
+        uses: ./
         with:
           action: delete
           milestone: ${{ steps.create.outputs.milestone-number }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,8 @@ jobs:
       # instead of the published action from a remote branch.
       - name: Checkout
         uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
       - name: Create Milestone
         id: create

--- a/.github/workflows/cr.yml
+++ b/.github/workflows/cr.yml
@@ -25,19 +25,16 @@ jobs:
         uses: hustcer/deepseek-review@main
         with:
           max-length: 50000
-          # model: 'deepseek-v3'                          # Infinigence's DeepSeek V3 model
-          model: 'deepseek-r1'                            # Infinigence's DeepSeek R1 model
+          # model: 'deepseek-v4'                          # Infinigence's DeepSeek V4 model
+          model: 'deepseek-flash'                         # Infinigence's DeepSeek flash model
           base-url: 'https://cloud.infini-ai.com/maas/v1' # Infinigence's API base URL
-          # model: 'deepseek-ai/DeepSeek-V3'              # SiliconFlow's DeepSeek V3 model
-          # model: 'deepseek-ai/DeepSeek-R1'              # SiliconFlow's DeepSeek R1 model
-          # base-url: 'https://api.siliconflow.cn/v1'     # SiliconFlow's API base URL
           # Store the chat token in GitHub Secrets, don't expose it in the workflow file
           chat-token: ${{ secrets.CHAT_TOKEN }}
           sys-prompt: >
             As a senior Nushell engineer, perform comprehensive script review with focus on:
 
             ### 1. Core Requirements:
-            - Validate Nu 0.108+ compatibility
+            - Validate Nu 0.112+ compatibility
             - Check structured data handling
             - Verify pipeline efficiency
             - Assess module organization
@@ -55,7 +52,7 @@ jobs:
             - Parallel execution opportunities
 
             **Rules:**
-            - Target Nu 0.108+ features
+            - Target Nu 0.112+ features
             - Highlight data flow vulnerabilities
             - Suggest structured data optimizations
             - Keep feedback Nu-specific

--- a/.github/workflows/cr.yml
+++ b/.github/workflows/cr.yml
@@ -26,7 +26,7 @@ jobs:
         with:
           max-length: 50000
           # model: 'deepseek-v4'                          # Infinigence's DeepSeek V4 model
-          model: 'deepseek-flash'                         # Infinigence's DeepSeek flash model
+          model: 'deepseek-v4-flash'                      # Infinigence's DeepSeek flash model
           base-url: 'https://cloud.infini-ai.com/maas/v1' # Infinigence's API base URL
           # Store the chat token in GitHub Secrets, don't expose it in the workflow file
           chat-token: ${{ secrets.CHAT_TOKEN }}

--- a/action.yaml
+++ b/action.yaml
@@ -75,19 +75,34 @@ runs:
     - name: Set Milestone
       shell: nu {0}
       id: action
+      # Inputs are passed through the environment instead of being interpolated into the
+      # script body. `${{ }}` expansion happens before the script is written to disk, so
+      # any input containing a quote could otherwise break out of the string literal and
+      # execute arbitrary Nushell code on the runner.
+      env:
+        INPUT_ACTION: ${{ inputs.action }}
+        INPUT_TITLE: ${{ inputs.title }}
+        INPUT_FORCE: ${{ inputs.force }}
+        INPUT_DUE_ON: ${{ inputs.due-on }}
+        INPUT_MILESTONE: ${{ inputs.milestone }}
+        INPUT_DESCRIPTION: ${{ inputs.description }}
+        INPUT_GITHUB_TOKEN: ${{ inputs.github-token }}
+        INPUT_INHERIT_FROM_ISSUE: ${{ inputs.inherit-from-issue }}
+        EVENT_ISSUE_NUMBER: ${{ github.event.issue.number }}
+        EVENT_PR_NUMBER: ${{ github.event.pull_request.number }}
       run: |
         use ${{ github.action_path }}/nu/milestone.nu *
-        let action = '${{ inputs.action }}'
-        let repo = '${{ github.repository }}'
-        let title = '${{ inputs.title }}'
-        let dueOn = '${{ inputs.due-on }}'
-        let description = '${{ inputs.description }}'
-        let token = '${{ inputs.github-token }}'
-        let milestone = '${{ inputs.milestone }}'
-        let issue = '${{ github.event.issue.number }}'
-        let pr = '${{ github.event.pull_request.number }}'
-        let force = '${{ inputs.force }}' | into bool
-        let inheritFromIssue = '${{ inputs.inherit-from-issue }}' | into bool
+        let action = $env.INPUT_ACTION
+        let repo = $env.GITHUB_REPOSITORY
+        let title = $env.INPUT_TITLE
+        let dueOn = $env.INPUT_DUE_ON
+        let description = $env.INPUT_DESCRIPTION
+        let token = $env.INPUT_GITHUB_TOKEN
+        let milestone = $env.INPUT_MILESTONE
+        let issue = $env.EVENT_ISSUE_NUMBER
+        let pr = $env.EVENT_PR_NUMBER
+        let force = if ($env.INPUT_FORCE | is-empty) { false } else { $env.INPUT_FORCE | into bool }
+        let inheritFromIssue = if ($env.INPUT_INHERIT_FROM_ISSUE | is-empty) { true } else { $env.INPUT_INHERIT_FROM_ISSUE | into bool }
         (milestone-action $action $repo
           --pr=$pr
           --issue=$issue

--- a/nu/query.nu
+++ b/nu/query.nu
@@ -11,6 +11,10 @@
 
 use common.nu [hr-line]
 
+# Resolve the directory of this module at parse time, so that the `.gql` files can be
+# located no matter what the current working directory or the entry script path is.
+const GQL_DIR = path self .
+
 export def query-issue-closer-by-graphql [
   repo: string,         # Github repository name
   issueNO: int,         # Issue number
@@ -18,8 +22,7 @@ export def query-issue-closer-by-graphql [
 ] {
   let owner = $repo | split row / | first
   let name = $repo | split row / | last
-  let pwd = $env.FILE_PWD? | default 'nu'
-  let query = open -r $'($pwd)/issue.gql'
+  let query = open -r ($GQL_DIR | path join 'issue.gql')
   let variables = {
     repo_name: $name,
     repo_owner: $owner,
@@ -79,8 +82,7 @@ export def query-pr-closing-issues [
 ] {
   let owner = $repo | split row / | first
   let name = $repo | split row / | last
-  let pwd = $env.FILE_PWD? | default 'nu'
-  let query = open -r $'($pwd)/pr.gql'
+  let query = open -r ($GQL_DIR | path join 'pr.gql')
   let variables = {
     pr_number: $prNO,
     repo_name: $name,


### PR DESCRIPTION
- action.yaml: pass every `inputs.*` and event field through `env:` instead of interpolating them into the Nushell script body. `${{ }}` expansion happens before the step script is written to disk, so a single quote in `title`, `description`, `milestone` or `github-token` could close the Nu string literal and execute arbitrary code on the runner.
- action.yaml: treat an empty `force` / `inherit-from-issue` as its documented default instead of failing on `'' | into bool`.
- nu/query.nu: resolve `issue.gql` / `pr.gql` through a `path self` const. The lookup previously used `$env.FILE_PWD`, which is never set inside a module function; it only worked because `milestone.nu`'s `export-env` block leaked the module-eval-time `FILE_PWD` back to the caller. Dropping that block would have silently broken `bind-issue` and `inherit-from-issue`, and `use query.nu` on its own already failed with "File not found".
- .github/workflows/ci.yml: check out the repo and use `./` so CI exercises the code under review instead of the published action from a remote branch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved action reliability by safely handling inputs and event values during execution.
  * Ensured GraphQL queries load correctly regardless of the directory from which the action runs.

* **Tests**
  * Updated continuous integration checks to validate local milestone creation, closure, and deletion workflows.

* **Chores**
  * Updated Nushell compatibility targets and refreshed the AI model used in continuous workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->