### PR TITLE
fix: Look up milestones by title across all states with pagination

### DIFF
--- a/nu/milestone.nu
+++ b/nu/milestone.nu
@@ -160,8 +160,9 @@ export def guess-milestone-for-pr [
 
   # Fall back to date-based milestone detection
   print $'(char nl)Using date-based milestone detection for PR (ansi p)#($pr)(ansi reset)...'
-  # Query github open milestone list by gh
-  let milestones = gh api -X GET $'/repos/($repo)/milestones' --paginate | from json
+  # Query github open milestone list by gh. `state=open` is intentional here:
+  # date-based detection should only ever consider milestones still open.
+  let milestones = gh api -X GET $'/repos/($repo)/milestones' -f state=open --paginate | from json
     | select number title due_on created_at html_url
   if ($milestones | is-empty) {
     print 'No open milestones found.'
@@ -246,12 +247,11 @@ export def close-milestone [
   check-gh
   if ($gh_token | is-not-empty) { $env.GH_TOKEN = $gh_token }
   let milestoneId = if ($milestone | is-int) { $milestone } else {
-    let milestones = gh api $'/repos/($repo)/milestones' | from json
-    let milestone = $milestones | where title == $milestone
-    if ($milestone | is-empty) {
+    let found = list-milestones $repo | where title == $milestone
+    if ($found | is-empty) {
       print 'Milestone not found.'; exit $ECODE.INVALID_PARAMETER
     }
-    $milestone.0.number
+    $found.0.number
   }
   let result = gh api -X PATCH $'/repos/($repo)/milestones/($milestoneId)' -F $'state=closed'
   let milestone = $result | from json
@@ -268,12 +268,11 @@ export def delete-milestone [
   check-gh
   if ($gh_token | is-not-empty) { $env.GH_TOKEN = $gh_token }
   let milestoneId = if ($milestone | is-int) { $milestone } else {
-    let milestones = gh api $'/repos/($repo)/milestones' | from json
-    let milestone = $milestones | where title == $milestone
-    if ($milestone | is-empty) {
+    let found = list-milestones $repo | where title == $milestone
+    if ($found | is-empty) {
       print 'Milestone not found.'; exit $ECODE.INVALID_PARAMETER
     }
-    $milestone.0.number
+    $found.0.number
   }
   let result = gh api -X DELETE $'/repos/($repo)/milestones/($milestoneId)'
   let response = $result | from json
@@ -294,13 +293,19 @@ def check-gh [] {
   }
 }
 
+# List every milestone of a repository, open and closed alike.
+# `state=all` is required because the REST API defaults to `state=open`, and
+# `--paginate` because a single page only holds 30 milestones.
+def list-milestones [repo: string] {
+  gh api -X GET $'/repos/($repo)/milestones' -f state=all --paginate | from json
+}
+
 # Get milestone number by title using REST API
 def get-milestone-number [
   repo: string,
   milestone_title: string
 ] {
-  let milestones = gh api -X GET $'/repos/($repo)/milestones' --paginate | from json
-  let found = $milestones | where title == $milestone_title
+  let found = list-milestones $repo | where title == $milestone_title
   if ($found | is-empty) {
     print $'(ansi r)Error:(ansi reset) Milestone (ansi p)($milestone_title)(ansi reset) not found in repository (ansi p)($repo)(ansi reset).'
     return null
@@ -344,7 +349,7 @@ export def milestone-action [
   --pr: string,                 # The PR number/url/branch of the PR that we want to add milestone.
   --issue: string,              # The Issue number that we want to add milestone.
   --force(-f),                  # Force update milestone even if the milestone is already set.
-  --dry-run(-d),                # Dry run, only print the milestone that would be set.
+  --dry-run,                    # Dry run, only print the milestone that would be set.
   --inherit-from-issue = true,  # Try to inherit milestone from closing issues. Defaults to true.
 ] {
   match $action {
@@ -353,6 +358,7 @@ export def milestone-action [
     create => { create-milestone $repo $title --due-on $due_on -D $description -t $gh_token },
     bind-pr => { milestone-bind-for-pr $repo -t $gh_token -m $milestone --pr $pr --force=$force --dry-run=$dry_run --inherit-from-issue=$inherit_from_issue },
     bind-issue => { milestone-bind-for-issue $repo -t $gh_token -m $milestone --issue ($issue | into int) --force=$force --dry-run=$dry_run },
+    _ => { error make { msg: $'Invalid action: ($action)' } },
   }
 }
 


### PR DESCRIPTION
fixes #169 

The REST API `GET /repos/{owner}/{repo}/milestones` defaults to `state=open` and returns only 30 items per page, so title-based lookups silently missed closed milestones and anything past the first page.

- Add a `list-milestones` helper querying `state=all` with `--paginate`
- Use it in `close-milestone`, `delete-milestone` and `get-milestone-number`, replacing three copies of the same query
- Fix `delete-milestone`/`close-milestone` failing with "Milestone not found" on closed milestones; `close-milestone` is now idempotent
- Fix binding a PR/issue to an explicitly named closed milestone
- Drop the `$milestone` self-shadowing in the close/delete lookup blocks
- Make the open-only filter explicit in `guess-milestone-for-pr`, where date-based detection should only ever consider open milestones

Verified against nushell/nushell: 2 milestones returned before, 63 after.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Milestone detection now considers only open milestones, providing more accurate results.
  - Milestone actions can reliably find milestones across both open and closed statuses, including large milestone lists.
- **Command-Line Changes**
  - The dry-run option now uses `--dry-run`; the `-d` shortcut has been removed.
  - Unsupported milestone actions now produce a clear error instead of proceeding unexpectedly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->