### PR TITLE
fix: Guard GITHUB_OUTPUT, surface GraphQL errors and tighten is-int

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -55,6 +55,6 @@ di *OPTIONS:
   @overlay use {{ join(MILESTONE_ACTION_PATH, 'nu', 'milestone.nu') }}; \
   milestone-action bind-issue {{OPTIONS}} --dry-run
 
-# Plugins need to be registered only once after nu v0.61
+# Plugins need to be added only once, `register` was replaced by `plugin add` in nu v0.93
 _setup:
-  @register -e json {{ join(NU_DIR, _query_plugin) }}
+  @plugin add {{ join(NU_DIR, _query_plugin) }}

--- a/nu/milestone.nu
+++ b/nu/milestone.nu
@@ -42,16 +42,8 @@ export def 'milestone-bind-for-pr' [
   let token = $env.GH_TOKEN? | default $env.GITHUB_TOKEN?
   let selected = if ($milestone | is-empty) { guess-milestone-for-pr $repo $pr $token $inherit_from_issue } else { $milestone }
   let prevMilestone = gh pr view $pr --repo $repo --json 'milestone' | from json | get milestone?.title? | default '-'
-  if $force {
-    let shouldRemove = $prevMilestone != $selected
-    if $dry_run and $shouldRemove {
-      print $'(char nl)Would remove milestone for PR (ansi p)($pr)(ansi reset) in repository (ansi p)($repo)(ansi reset) ...'
-    } else if $shouldRemove {
-      gh pr edit $pr --repo $repo --remove-milestone
-    } else {
-      print $'(char nl)Milestone for PR (ansi p)($pr)(ansi reset) in repo (ansi p)($repo)(ansi reset) was already set to (ansi p)($prevMilestone)(ansi reset), will be ignored.'
-    }
-  }
+  # No explicit removal is needed on the force path: the REST PATCH below overwrites
+  # whatever milestone is currently set.
   let ignoreSet = not $force and $prevMilestone != '-'
   if $prevMilestone == $selected or $ignoreSet {
     print $'(char nl)Milestone for PR (ansi p)($pr)(ansi reset) in repo (ansi p)($repo)(ansi reset) was already set to (ansi p)($prevMilestone)(ansi reset), will be ignored.'
@@ -91,16 +83,8 @@ export def 'milestone-bind-for-issue' [
   let token = $env.GH_TOKEN? | default $env.GITHUB_TOKEN?
   let selected = if ($milestone | is-empty) { query-issue-closer-by-graphql $repo $issue $token | get closedBy?.milestone? | default '-' } else { $milestone }
   let prevMilestone = gh issue view $issue --repo $repo --json 'milestone' | from json | get milestone?.title? | default '-'
-  if $force {
-    let shouldRemove = $prevMilestone != $selected
-    if $dry_run and $shouldRemove {
-      print $'(char nl)Would remove milestone for Issue (ansi p)($issue)(ansi reset) in repository (ansi p)($repo)(ansi reset) ...'
-    } else if $shouldRemove {
-      gh issue edit $issue --repo $repo --remove-milestone
-    } else {
-      print $'(char nl)Milestone for Issue (ansi p)($issue)(ansi reset) in repo (ansi p)($repo)(ansi reset) was already set to (ansi p)($prevMilestone)(ansi reset), will be ignored.'
-    }
-  }
+  # No explicit removal is needed on the force path: the REST PATCH below overwrites
+  # whatever milestone is currently set.
   if $selected == '-' {
     print $'No milestone found for issue (ansi p)($issue)(ansi reset) in repository (ansi p)($repo)(ansi reset).'
     return
@@ -235,7 +219,7 @@ export def create-milestone [
   let result = gh api -X POST $'/repos/($repo)/milestones' -F $'title=($title)' ...$dueOnArg ...$descArg
   let milestone = $result | from json
   print $'Milestone (ansi p)($milestone.title)(ansi reset) with NO. (ansi p)($milestone.number)(ansi reset) was created successfully.'
-  echo $'milestone-number=($milestone.number)' o>> $env.GITHUB_OUTPUT
+  set-action-output 'milestone-number' $milestone.number
 }
 
 # Close milestone for a repository by title or number.
@@ -256,7 +240,7 @@ export def close-milestone [
   let result = gh api -X PATCH $'/repos/($repo)/milestones/($milestoneId)' -F $'state=closed'
   let milestone = $result | from json
   print $'Milestone (ansi p)($milestone.title)(ansi reset) with NO. (ansi p)($milestone.number)(ansi reset) was closed successfully.'
-  echo $'milestone-number=($milestone.number)' o>> $env.GITHUB_OUTPUT
+  set-action-output 'milestone-number' $milestone.number
 }
 
 # Delete milestone for a repository by title or number.
@@ -280,10 +264,20 @@ export def delete-milestone [
   $response | table -ew 120 | print
 }
 
+# Write a key/value pair to $env.GITHUB_OUTPUT when running inside Github Actions.
+# Outside Actions (local `just`, manual debugging) the variable is absent, so this is a no-op.
+def set-action-output [key: string, value: any] {
+  if ($env.GITHUB_OUTPUT? | is-not-empty) {
+    $'($key)=($value)(char nl)' | save --append $env.GITHUB_OUTPUT
+  }
+}
+
+# Only plain ASCII digits count: `\d` in Rust regex matches the whole Unicode Nd
+# category, so '１２３' would otherwise be treated as a milestone number.
 def is-int [] {
   let value = $in | str trim
   if ($value | is-empty) { return false }
-  $value | str replace -ar '\d' '' | is-empty
+  $value =~ '^[0-9]+$'
 }
 
 def check-gh [] {

--- a/nu/query.nu
+++ b/nu/query.nu
@@ -36,6 +36,17 @@ export def query-issue-closer-by-graphql [
   $status
 }
 
+# Abort with the actual GraphQL diagnostics instead of letting a missing `data`
+# field surface later as an inscrutable column-not-found error.
+def check-graphql-errors [response: any] {
+  let errors = $response | get -o errors
+  if ($errors | is-not-empty) {
+    print $'(ansi r)GraphQL Error:(ansi reset)'
+    $errors | table -e | print
+    error make { msg: $'GraphQL query failed: ($errors | get -o 0.message | default "unknown error")' }
+  }
+}
+
 def query-issue-status [issueNO: int, payload: string, token: string] {
   let rename = {
     'author.login': 'author',
@@ -55,8 +66,9 @@ def query-issue-status [issueNO: int, payload: string, token: string] {
   loop {
     if $milestone != '-' or $tries > 5 { break }
     print $'Try to query milestone for issue (ansi p)($issueNO)(ansi reset) the (ansi p)($tries)(ansi reset) (if $tries == 1 { "time" } else { "times" }) ...'
-    $result = (http post --content-type application/json -H $HEADERS $QUERY_API $payload
-      | get data.repository.issueOrPullRequest)
+    let response = http post --content-type application/json -H $HEADERS $QUERY_API $payload
+    check-graphql-errors $response
+    $result = ($response | get data.repository.issueOrPullRequest)
 
     $events = $result.timeline.edges.node | where {|it| $it.stateReason? | is-not-empty }
 
@@ -95,11 +107,7 @@ export def query-pr-closing-issues [
 
   let response = http post --content-type application/json -H $HEADERS $QUERY_API $payload
 
-  # Check for errors in GraphQL response
-  if ($response | get -o errors) != null {
-    print $'(ansi r)GraphQL Error:(ansi reset)'
-    error make { msg: "GraphQL query failed" }
-  }
+  check-graphql-errors $response
 
   let result = $response | get data.repository.pullRequest
 

--- a/nu/release.nu
+++ b/nu/release.nu
@@ -11,6 +11,8 @@
 # Usage:
 #   Change `version` in meta.json and then run: `just release` OR `just release true`
 
+use common.nu [has-ref]
+
 export def 'make-release' [
   --update-log(-u)    # Add flag to enable updating CHANGELOG.md
 ] {


### PR DESCRIPTION
Fix several issues that only show up outside of Github Actions or on error paths:

- Guard `$env.GITHUB_OUTPUT` behind a `set-action-output` helper, so that `create`/`close` no longer fail with a column-not-found error when run locally via `just` or during manual debugging
- Add `check-graphql-errors` in `query.nu` and use it in both `query-issue-status` (which previously did no error checking at all) and `query-pr-closing-issues` (which discarded the error payload); the real diagnostics are now printed and the first message is carried in `error make`
- Drop the redundant `--remove-milestone` calls on the `--force` path: the REST PATCH is already overwrite semantics, and the extra call created a visible intermediate state plus a duplicated "will be ignored" message
- Make `is-int` match ASCII digits only, since `\d` in Rust regex covers the whole Unicode Nd category and accepted input like '１２３' as a milestone number
- Import `has-ref` from `common.nu` in `release.nu` instead of relying on the Justfile overlay
- Replace the long-removed `register -e json` with `plugin add` in `_setup`

closes #171 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved milestone replacement behavior when force-updating issues and pull requests.
  - Added clearer GraphQL error reporting for issue and pull request operations.
  - Improved validation of milestone numbers to reject invalid characters.
  - Made GitHub Actions output handling safer when workflow output is unavailable.

- **Compatibility**
  - Updated setup support for Nushell v0.93.
  - Improved release workflow reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->