### PR TITLE
fix: Require title for create action and sync stale docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,13 +22,20 @@ jobs:
         with:
           persist-credentials: false
 
+      # Derive the due date at run time: a hard-coded one silently drifts into the past
+      # and the "milestone due in the future" intent of this test quietly disappears.
+      - name: Compute Due Date
+        id: due
+        shell: bash
+        run: echo "date=$(date -u -d '+1 year' '+%Y-%m-%d')" >> "$GITHUB_OUTPUT"
+
       - name: Create Milestone
         id: create
         uses: ./
         with:
           action: create
           title: 'v0.0.1'
-          due-on: '2025/12/31'
+          due-on: ${{ steps.due.outputs.date }}
           description: 'Test Create Milestone'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -48,3 +55,19 @@ jobs:
           milestone: ${{ steps.create.outputs.milestone-number }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # `create` without a title used to fall back to a '1.0.0' placeholder milestone.
+      - name: Create Milestone Without Title
+        id: no-title
+        continue-on-error: true
+        uses: ./
+        with:
+          action: create
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Assert Create Without Title Failed
+        if: steps.no-title.outcome != 'failure'
+        shell: bash
+        run: |
+          echo '::error::`create` without a title should fail instead of creating a placeholder milestone'
+          exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,12 +22,21 @@ jobs:
         with:
           persist-credentials: false
 
+      # `shell: nu` needs Nu on the runner. The action installs it as well, but only
+      # from inside its own first step, which runs after this one.
+      - name: Setup Nu
+        uses: hustcer/setup-nu@v3.27
+        with:
+          version: '0.115.0'
+
       # Derive the due date at run time: a hard-coded one silently drifts into the past
       # and the "milestone due in the future" intent of this test quietly disappears.
       - name: Compute Due Date
         id: due
-        shell: bash
-        run: echo "date=$(date -u -d '+1 year' '+%Y-%m-%d')" >> "$GITHUB_OUTPUT"
+        shell: nu {0}
+        run: |
+          let dueOn = ((date now) | date to-timezone UTC) + 365day | format date '%Y-%m-%d'
+          $'date=($dueOn)(char nl)' | save --append $env.GITHUB_OUTPUT
 
       - name: Create Milestone
         id: create
@@ -67,7 +76,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Assert Create Without Title Failed
         if: steps.no-title.outcome != 'failure'
-        shell: bash
+        shell: nu {0}
         run: |
-          echo '::error::`create` without a title should fail instead of creating a placeholder milestone'
+          print '::error::`create` without a title should fail instead of creating a placeholder milestone'
           exit 1

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Create milestone by title, description and due date:
   with:
     action: create
     title: v1.0
-    due-on: 2025-05-01
+    due-on: 2026-05-01
     description: 'The first milestone of the project.'
   env:
     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -93,7 +93,7 @@ Delete milestone by title or milestone number:
 | Name               | Type    | Description                                                                                                                            |
 | ------------------ | ------- | -------------------------------------------------------------------------------------------------------------------------------------- |
 | action             | String  | Action to perform: create, close, delete, bind-pr, bind-issue, defaults to `bind-pr`                                                   |
-| title              | String  | Title of the milestone to create                                                                                                       |
+| title              | String  | Title of the milestone to create, required by the `create` action                                                                      |
 | due-on             | String  | Due date of the milestone to create (format: yyyy-mm-dd)                                                                               |
 | description        | String  | Description of the milestone to create                                                                                                 |
 | milestone          | String  | Title or number of the milestone to close or delete; can also be used to specify the milestone title to associate with the PR or issue |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -56,7 +56,7 @@ jobs:
   with:
     action: create
     title: v1.0
-    due-on: 2025-05-01
+    due-on: 2026-05-01
     description: 'The first milestone of the project.'
   env:
     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -91,7 +91,7 @@ jobs:
 | 名称               | 类型    | 描述                                                                                   |
 | ------------------ | ------- | -------------------------------------------------------------------------------------- |
 | action             | String  | 要执行的操作, 可能的值未：create, close, delete, bind-pr, bind-issue，默认为 `bind-pr` |
-| title              | String  | 要创建的里程碑标题                                                                     |
+| title              | String  | 要创建的里程碑标题，`create` 操作必填                                                  |
 | due-on             | String  | 要创建的里程碑的截止日期（yyyy-mm-dd）                                                 |
 | description        | String  | 要创建的里程碑描述信息                                                                 |
 | milestone          | String  | 要关闭或删除的里程碑标题或编号，也可用于指定要绑定到 PR 或 issue 的里程碑标题          |

--- a/action.yaml
+++ b/action.yaml
@@ -31,16 +31,16 @@ inputs:
     description: 'The action to perform, should be bind-pr,bind-issue,create, delete or close. Defaults to bind-pr.'
   title:
     required: false
-    default: '1.0.0'
-    description: 'The title of the milestone to create.'
+    default: ''
+    description: 'The title of the milestone to create. Required by the `create` action.'
   description:
     required: false
-    default: 'The first milestone.'
+    default: ''
     description: 'The description of the milestone to create.'
   due-on:
     required: false
     default: ''
-    description: 'The due date of the milestone to create.'
+    description: 'The due date of the milestone to create, format: yyyy-mm-dd.'
   force:
     required: false
     default: false

--- a/meta.json
+++ b/meta.json
@@ -6,5 +6,5 @@
   "license": "MIT",
   "github": "https://github.com/hustcer/milestone-action",
   "home": "https://github.com/marketplace/actions/milestone-action",
-  "description": "A Github action to create, close milestones and set milestone to merged PRs or closed issues."
+  "description": "A Github action to create, close, delete milestones and set milestone to merged PRs or closed issues."
 }

--- a/nu/milestone.nu
+++ b/nu/milestone.nu
@@ -207,12 +207,18 @@ export def guess-milestone-for-issue [
 export def create-milestone [
   repo: string,               # Github repository name
   title: string,              # Milestone title
-  --due-on(-d): string,       # Milestone due date, format: yyyy/mm/dd
+  --due-on(-d): string,       # Milestone due date, format: yyyy-mm-dd
   --description(-D): string,  # Milestone description
   --gh-token(-t): string,     # Github access token
 ] {
   check-gh
   const STD_TIME = '%Y-%m-%dT%H:%M:%SZ'
+  # A milestone without a title is always a mistake, and the Github API would happily
+  # create one from whatever placeholder we passed, so fail loudly instead.
+  if ($title | is-empty) {
+    print $'(ansi r)Error:(ansi reset) A non-empty `title` is required by the `create` action.'
+    exit $ECODE.INVALID_PARAMETER
+  }
   if ($gh_token | is-not-empty) { $env.GH_TOKEN = $gh_token }
   let dueOnArg = if ($due_on | is-empty) { [] } else { [-F $'due_on=($due_on | into datetime | format date $STD_TIME)'] }
   let descArg = if ($description | is-empty) { [] } else { [-F $'description=($description)'] }
@@ -337,8 +343,8 @@ export def milestone-action [
   repo: string,                 # Github repository name
   --gh-token(-t): string,       # Github access token
   --milestone(-m): string,      # Milestone name
-  --title: string,              # Milestone title to create or close
-  --due-on(-d): string,         # Milestone due date, format: yyyy/mm/dd
+  --title: string = '',         # Milestone title to create or close
+  --due-on(-d): string,         # Milestone due date, format: yyyy-mm-dd
   --description(-D): string,    # Milestone description
   --pr: string,                 # The PR number/url/branch of the PR that we want to add milestone.
   --issue: string,              # The Issue number that we want to add milestone.

--- a/nu/milestone.nu
+++ b/nu/milestone.nu
@@ -215,7 +215,7 @@ export def create-milestone [
   const STD_TIME = '%Y-%m-%dT%H:%M:%SZ'
   # A milestone without a title is always a mistake, and the Github API would happily
   # create one from whatever placeholder we passed, so fail loudly instead.
-  if ($title | is-empty) {
+  if ($title | str trim | is-empty) {
     print $'(ansi r)Error:(ansi reset) A non-empty `title` is required by the `create` action.'
     exit $ECODE.INVALID_PARAMETER
   }
@@ -343,7 +343,7 @@ export def milestone-action [
   repo: string,                 # Github repository name
   --gh-token(-t): string,       # Github access token
   --milestone(-m): string,      # Milestone name
-  --title: string = '',         # Milestone title to create or close
+  --title: string = '',         # Milestone title to create
   --due-on(-d): string,         # Milestone due date, format: yyyy-mm-dd
   --description(-D): string,    # Milestone description
   --pr: string,                 # The PR number/url/branch of the PR that we want to add milestone.


### PR DESCRIPTION
fix: Require title for create action and sync stale docs

The `create` action shipped placeholder defaults (`title: '1.0.0'`,
`description: 'The first milestone.'`), so forgetting to pass a title
silently produced a bogus `1.0.0` milestone instead of failing. The
due-on format was also documented three different ways, and the CI
due date had drifted into the past.

- action.yaml: default `title`/`description` to empty, mark title as required by `create`
- milestone.nu: reject an empty title in `create-milestone` with `INVALID_PARAMETER`
- milestone.nu: default `--title` to `''` so a missing flag hits that check, not a type error
- Standardize the due-on format on `yyyy-mm-dd` across action.yaml, milestone.nu and CI
- ci.yml: derive the due date at run time so the "due in the future" intent cannot expire
- ci.yml: add a regression step asserting `create` without a title fails
- meta.json: add the missing `delete` action to the description
- README/README.zh-CN: note that `title` is required by `create`, refresh example dates

Closes #173 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The action now supports deleting milestones.
  * Milestone due dates use the `yyyy-mm-dd` format.
* **Bug Fixes**
  * Creating a milestone without a title now returns a validation error.
  * Milestone due dates in automated workflows are calculated dynamically.
* **Documentation**
  * Updated usage examples and input documentation.
  * Clarified that titles are required for creation and documented default input values and supported milestone operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->