### PR TITLE
fix: Send milestone fields as raw strings and harden action inputs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,7 @@ on:
 
 # Fix GraphQL: Resource not accessible by integration (updatePullRequest)
 permissions:
+  contents: read
   pull-requests: write
 
 jobs:
@@ -22,21 +23,14 @@ jobs:
         with:
           persist-credentials: false
 
-      # `shell: nu` needs Nu on the runner. The action installs it as well, but only
-      # from inside its own first step, which runs after this one.
-      - name: Setup Nu
-        uses: hustcer/setup-nu@v3.27
-        with:
-          version: '0.115.0'
-
       # Derive the due date at run time: a hard-coded one silently drifts into the past
       # and the "milestone due in the future" intent of this test quietly disappears.
+      # Deliberately not a `nu` step: `nu` is only on the runner once the action's own
+      # Setup Nu step has run, so a step before that one would need a second version
+      # pin here, free to drift away from the one in `action.yaml`.
       - name: Compute Due Date
         id: due
-        shell: nu {0}
-        run: |
-          let dueOn = ((date now) | date to-timezone UTC) + 365day | format date '%Y-%m-%d'
-          $'date=($dueOn)(char nl)' | save --append $env.GITHUB_OUTPUT
+        run: echo "date=$(date -u -d '+365 days' '+%Y-%m-%d')" >> "$GITHUB_OUTPUT"
 
       - name: Create Milestone
         id: create
@@ -48,6 +42,7 @@ jobs:
           description: 'Test Create Milestone'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Close Milestone
         id: close
         uses: ./
@@ -56,12 +51,42 @@ jobs:
           milestone: 'v0.0.1'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # Resolving a title has to search closed milestones too, otherwise closing an
+      # already-closed one fails with "Milestone not found" instead of being a no-op.
+      - name: Close Milestone Again
+        uses: ./
+        with:
+          action: close
+          milestone: 'v0.0.1'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Delete Milestone
         id: delete
         uses: ./
         with:
           action: delete
           milestone: ${{ steps.create.outputs.milestone-number }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # A purely numeric title used to reach the API as a JSON number, which the
+      # milestones endpoint rejects with `422 ... 20260821 is not a string`.
+      # Deleted by number: an all-digit `milestone` value always routes to the number path.
+      - name: Create Milestone With Numeric Title
+        id: numeric
+        uses: ./
+        with:
+          action: create
+          title: '20260821'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Delete Milestone With Numeric Title
+        uses: ./
+        with:
+          action: delete
+          milestone: ${{ steps.numeric.outputs.milestone-number }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/close.yml
+++ b/.github/workflows/close.yml
@@ -1,7 +1,7 @@
 # Description:
 #   - Close a milestone by title or number.
 
-name: Milestone Close@develop
+name: Milestone Close@local
 on:
   workflow_dispatch:
     inputs:
@@ -11,6 +11,7 @@ on:
 
 # Fix GraphQL: Resource not accessible by integration (updatePullRequest)
 permissions:
+  contents: read
   pull-requests: write
 
 jobs:
@@ -18,9 +19,16 @@ jobs:
     runs-on: ubuntu-latest
     name: Close Milestone
     steps:
+      # Required by `uses: ./`: a dispatched run should exercise the branch it was
+      # dispatched from, not whatever `@develop` happened to point at.
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
       - name: Close Milestone
         id: close
-        uses: hustcer/milestone-action@develop
+        uses: ./
         with:
           action: close
           milestone: ${{ github.event.inputs.milestone }}

--- a/.github/workflows/cr.yml
+++ b/.github/workflows/cr.yml
@@ -34,7 +34,7 @@ jobs:
             As a senior Nushell engineer, perform comprehensive script review with focus on:
 
             ### 1. Core Requirements:
-            - Validate Nu 0.112+ compatibility
+            - Validate Nu 0.115+ compatibility
             - Check structured data handling
             - Verify pipeline efficiency
             - Assess module organization
@@ -52,7 +52,7 @@ jobs:
             - Parallel execution opportunities
 
             **Rules:**
-            - Target Nu 0.112+ features
+            - Target Nu 0.115+ features
             - Highlight data flow vulnerabilities
             - Suggest structured data optimizations
             - Keep feedback Nu-specific

--- a/.github/workflows/create.yml
+++ b/.github/workflows/create.yml
@@ -1,7 +1,7 @@
 # Description:
 #   - Create a milestone by title, description and due date.
 
-name: Milestone Create@develop
+name: Milestone Create@local
 on:
   workflow_dispatch:
     inputs:
@@ -17,6 +17,7 @@ on:
 
 # Fix GraphQL: Resource not accessible by integration (updatePullRequest)
 permissions:
+  contents: read
   pull-requests: write
 
 jobs:
@@ -24,9 +25,16 @@ jobs:
     runs-on: ubuntu-latest
     name: Create Milestone
     steps:
+      # Required by `uses: ./`: a dispatched run should exercise the branch it was
+      # dispatched from, not whatever `@develop` happened to point at.
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
       - name: Create Milestone
         id: create
-        uses: hustcer/milestone-action@develop
+        uses: ./
         with:
           action: create
           title: ${{ github.event.inputs.title }}

--- a/.github/workflows/delete.yml
+++ b/.github/workflows/delete.yml
@@ -1,7 +1,7 @@
 # Description:
 #   - Delete a milestone by title or number.
 
-name: Milestone Delete@develop
+name: Milestone Delete@local
 on:
   workflow_dispatch:
     inputs:
@@ -11,6 +11,7 @@ on:
 
 # Fix GraphQL: Resource not accessible by integration (updatePullRequest)
 permissions:
+  contents: read
   pull-requests: write
 
 jobs:
@@ -18,9 +19,16 @@ jobs:
     runs-on: ubuntu-latest
     name: Delete Milestone
     steps:
+      # Required by `uses: ./`: a dispatched run should exercise the branch it was
+      # dispatched from, not whatever `@develop` happened to point at.
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
       - name: Delete Milestone
         id: delete
-        uses: hustcer/milestone-action@develop
+        uses: ./
         with:
           action: delete
           milestone: ${{ github.event.inputs.milestone }}

--- a/README.md
+++ b/README.md
@@ -101,8 +101,9 @@ Delete milestone by title or milestone number:
 | inherit-from-issue | Boolean | Try to inherit milestone from closing issues for bind-pr action. Defaults to `true`                                                    |
 | github-token       | String  | The GitHub token to access the API for milestone management, defaults to `${{ github.token }}`                                         |
 
-> **Note:** an all-digit `milestone` value is always read as a milestone **number**, never as a title.
-> A milestone whose title is all digits (e.g. `20260821`) must therefore be closed or deleted by its number.
+> **Note:** for `close` and `delete`, an all-digit `milestone` value is read as a milestone **number**, never as a
+> title, so a milestone whose title is all digits (e.g. `20260821`) must be closed or deleted by its number.
+> For `bind-pr` and `bind-issue`, `milestone` is matched by **title** only.
 
 ### FAQ
 

--- a/README.md
+++ b/README.md
@@ -97,9 +97,12 @@ Delete milestone by title or milestone number:
 | due-on             | String  | Due date of the milestone to create (format: yyyy-mm-dd)                                                                               |
 | description        | String  | Description of the milestone to create                                                                                                 |
 | milestone          | String  | Title or number of the milestone to close or delete; can also be used to specify the milestone title to associate with the PR or issue |
-| force              | Boolean | If the PR or issue already has a milestone, remove it and assign a new one when they differ                                            |
+| force              | Boolean | If the PR or issue already has a milestone, overwrite it when the new one differs                                                      |
 | inherit-from-issue | Boolean | Try to inherit milestone from closing issues for bind-pr action. Defaults to `true`                                                    |
 | github-token       | String  | The GitHub token to access the API for milestone management, defaults to `${{ github.token }}`                                         |
+
+> **Note:** an all-digit `milestone` value is always read as a milestone **number**, never as a title.
+> A milestone whose title is all digits (e.g. `20260821`) must therefore be closed or deleted by its number.
 
 ### FAQ
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -95,9 +95,12 @@ jobs:
 | due-on             | String  | 要创建的里程碑的截止日期（yyyy-mm-dd）                                                 |
 | description        | String  | 要创建的里程碑描述信息                                                                 |
 | milestone          | String  | 要关闭或删除的里程碑标题或编号，也可用于指定要绑定到 PR 或 issue 的里程碑标题          |
-| force              | Boolean | 如果 PR 或 Issue 已有里程碑，且与新的不同，则移除旧的并设置新的                        |
+| force              | Boolean | 如果 PR 或 Issue 已有里程碑，且与新的不同，则直接覆盖                                  |
 | inherit-from-issue | Boolean | 对于 bind-pr 操作，尝试从关闭的 issues 继承里程碑。默认为 `true`                       |
 | github-token       | String  | 用于访问 API 进行里程碑管理的 GitHub Token，默认为 `${{ github.token }}`               |
+
+> **注意：** 全部由数字组成的 `milestone` 取值一律按里程碑**编号**解析，而非标题。
+> 因此标题为纯数字的里程碑（如 `20260821`）只能通过编号关闭或删除。
 
 ### 常见问题
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -99,8 +99,9 @@ jobs:
 | inherit-from-issue | Boolean | 对于 bind-pr 操作，尝试从关闭的 issues 继承里程碑。默认为 `true`                       |
 | github-token       | String  | 用于访问 API 进行里程碑管理的 GitHub Token，默认为 `${{ github.token }}`               |
 
-> **注意：** 全部由数字组成的 `milestone` 取值一律按里程碑**编号**解析，而非标题。
+> **注意：** 对 `close` 和 `delete`，全部由数字组成的 `milestone` 取值按里程碑**编号**解析，而非标题，
 > 因此标题为纯数字的里程碑（如 `20260821`）只能通过编号关闭或删除。
+> 对 `bind-pr` 和 `bind-issue`，`milestone` 仅按**标题**匹配。
 
 ### 常见问题
 

--- a/action.yaml
+++ b/action.yaml
@@ -48,7 +48,7 @@ inputs:
   milestone:
     required: false
     default: ''
-    description: 'The milestone to set, close or delete, by title or number. An all-digit value is always read as a number, never as a title.'
+    description: 'The milestone to set, close or delete. `close`/`delete` take a title or a number, and an all-digit value is read as a number. `bind-pr`/`bind-issue` match by title only.'
   inherit-from-issue:
     required: false
     default: true

--- a/action.yaml
+++ b/action.yaml
@@ -48,7 +48,7 @@ inputs:
   milestone:
     required: false
     default: ''
-    description: 'The milestone to set, close or delete.'
+    description: 'The milestone to set, close or delete, by title or number. An all-digit value is always read as a number, never as a title.'
   inherit-from-issue:
     required: false
     default: true
@@ -92,6 +92,7 @@ runs:
         EVENT_PR_NUMBER: ${{ github.event.pull_request.number }}
       run: |
         use ${{ github.action_path }}/nu/milestone.nu *
+        use ${{ github.action_path }}/nu/common.nu [parse-bool]
         let action = $env.INPUT_ACTION
         let repo = $env.GITHUB_REPOSITORY
         let title = $env.INPUT_TITLE
@@ -101,8 +102,8 @@ runs:
         let milestone = $env.INPUT_MILESTONE
         let issue = $env.EVENT_ISSUE_NUMBER
         let pr = $env.EVENT_PR_NUMBER
-        let force = if ($env.INPUT_FORCE | is-empty) { false } else { $env.INPUT_FORCE | into bool }
-        let inheritFromIssue = if ($env.INPUT_INHERIT_FROM_ISSUE | is-empty) { true } else { $env.INPUT_INHERIT_FROM_ISSUE | into bool }
+        let force = $env.INPUT_FORCE | parse-bool false
+        let inheritFromIssue = $env.INPUT_INHERIT_FROM_ISSUE | parse-bool true
         (milestone-action $action $repo
           --pr=$pr
           --issue=$issue

--- a/nu/common.nu
+++ b/nu/common.nu
@@ -48,6 +48,25 @@ export def get-env [
   $env | get -o $key | default $default
 }
 
+# Parse a Github Actions input into a boolean. Every input reaches the action as a string,
+# and `into bool` only understands 'true'/'false'/'1'/'0' - a perfectly reasonable `force: yes`
+# would otherwise abort the run with a raw Nushell conversion error. An empty string means the
+# input was not supplied, so it falls back to that input's documented default.
+export def parse-bool [
+  fallback: bool,   # The value to use when the input is empty
+]: string -> bool {
+  let value = $in | str trim | str lowercase
+  if ($value | is-empty) { return $fallback }
+  match $value {
+    'true' | 'yes' | 'on' | '1' => true,
+    'false' | 'no' | 'off' | '0' => false,
+    _ => {
+      print $'(ansi r)Error:(ansi reset) Expected a boolean value, got (ansi p)($value)(ansi reset).'
+      exit $ECODE.INVALID_PARAMETER
+    },
+  }
+}
+
 # Check if a git repo has the specified ref: could be a branch or tag, etc.
 export def has-ref [
   ref: string   # The git ref to check

--- a/nu/milestone.nu
+++ b/nu/milestone.nu
@@ -27,7 +27,7 @@ export def 'milestone-bind-for-pr' [
   --milestone(-m): string,      # Milestone name
   --pr: string,                 # The PR number/url/branch of the PR that we want to add milestone.
   --force(-f),                  # Force update milestone even if the milestone is already set.
-  --dry-run(-d),                # Dry run, only print the milestone that would be set.
+  --dry-run,                    # Dry run, only print the milestone that would be set.
   --inherit-from-issue = true,  # Try to inherit milestone from closing issues. Defaults to true.
 ] {
   check-gh
@@ -39,7 +39,7 @@ export def 'milestone-bind-for-pr' [
     print $'PR (ansi p)($pr)(ansi reset) is in state (ansi p)($prState)(ansi reset), will be ignored.'
     return
   }
-  let token = $env.GH_TOKEN? | default $env.GITHUB_TOKEN?
+  let token = resolve-gh-token
   let selected = if ($milestone | is-empty) { guess-milestone-for-pr $repo $pr $token $inherit_from_issue } else { $milestone }
   let prevMilestone = gh pr view $pr --repo $repo --json 'milestone' | from json | get milestone?.title? | default '-'
   # No explicit removal is needed on the force path: the REST PATCH below overwrites
@@ -67,7 +67,7 @@ export def 'milestone-bind-for-issue' [
   --milestone(-m): string,  # Milestone name
   --issue: int,             # The Issue number that we want to add milestone.
   --force(-f),              # Force update milestone even if the milestone is already set.
-  --dry-run(-d),            # Dry run, only print the milestone that would be set.
+  --dry-run,                # Dry run, only print the milestone that would be set.
 ] {
   check-gh
   if ($gh_token | is-not-empty) { $env.GH_TOKEN = $gh_token }
@@ -80,15 +80,20 @@ export def 'milestone-bind-for-issue' [
     print $'Issue (ansi p)($issue)(ansi reset) is Not (ansi p)COMPLETED(ansi reset), will be ignored.'
     return
   }
-  let token = $env.GH_TOKEN? | default $env.GITHUB_TOKEN?
+  let token = resolve-gh-token
   let selected = if ($milestone | is-empty) { query-issue-closer-by-graphql $repo $issue $token | get closedBy?.milestone? | default '-' } else { $milestone }
   let prevMilestone = gh issue view $issue --repo $repo --json 'milestone' | from json | get milestone?.title? | default '-'
-  # No explicit removal is needed on the force path: the REST PATCH below overwrites
-  # whatever milestone is currently set.
   if $selected == '-' {
+    # Nothing to bind. `--force` deliberately does NOT strip the existing milestone here:
+    # failing to infer a replacement is no reason to throw away one somebody set by hand.
     print $'No milestone found for issue (ansi p)($issue)(ansi reset) in repository (ansi p)($repo)(ansi reset).'
+    if $force and $prevMilestone != '-' {
+      print $'Keeping the existing milestone (ansi p)($prevMilestone)(ansi reset): (ansi p)--force(ansi reset) has no replacement to apply.'
+    }
     return
   }
+  # No explicit removal is needed on the force path: the REST PATCH below overwrites
+  # whatever milestone is currently set.
   let ignoreSet = not $force and $prevMilestone != '-'
   if $prevMilestone == $selected or $ignoreSet {
     print $'(char nl)Milestone for Issue (ansi p)($issue)(ansi reset) in repo (ansi p)($repo)(ansi reset) was already set to (ansi p)($prevMilestone)(ansi reset), will be ignored.'
@@ -220,9 +225,12 @@ export def create-milestone [
     exit $ECODE.INVALID_PARAMETER
   }
   if ($gh_token | is-not-empty) { $env.GH_TOKEN = $gh_token }
-  let dueOnArg = if ($due_on | is-empty) { [] } else { [-F $'due_on=($due_on | into datetime | format date $STD_TIME)'] }
-  let descArg = if ($description | is-empty) { [] } else { [-F $'description=($description)'] }
-  let result = gh api -X POST $'/repos/($repo)/milestones' -F $'title=($title)' ...$dueOnArg ...$descArg
+  # Always `-f` (raw-field), never `-F`: `-F` applies "magic type conversion", so a purely
+  # numeric title such as `2026` would be sent as a JSON number and rejected by the API with
+  # `422 Invalid request. For 'properties/title', 2026 is not a string.`
+  let dueOnArg = if ($due_on | is-empty) { [] } else { [-f $'due_on=($due_on | into datetime | format date $STD_TIME)'] }
+  let descArg = if ($description | is-empty) { [] } else { [-f $'description=($description)'] }
+  let result = gh api -X POST $'/repos/($repo)/milestones' -f $'title=($title)' ...$dueOnArg ...$descArg
   let milestone = $result | from json
   print $'Milestone (ansi p)($milestone.title)(ansi reset) with NO. (ansi p)($milestone.number)(ansi reset) was created successfully.'
   set-action-output 'milestone-number' $milestone.number
@@ -236,14 +244,8 @@ export def close-milestone [
 ] {
   check-gh
   if ($gh_token | is-not-empty) { $env.GH_TOKEN = $gh_token }
-  let milestoneId = if ($milestone | is-int) { $milestone } else {
-    let found = list-milestones $repo | where title == $milestone
-    if ($found | is-empty) {
-      print 'Milestone not found.'; exit $ECODE.INVALID_PARAMETER
-    }
-    $found.0.number
-  }
-  let result = gh api -X PATCH $'/repos/($repo)/milestones/($milestoneId)' -F $'state=closed'
+  let milestoneId = resolve-milestone-id $repo $milestone
+  let result = gh api -X PATCH $'/repos/($repo)/milestones/($milestoneId)' -f $'state=closed'
   let milestone = $result | from json
   print $'Milestone (ansi p)($milestone.title)(ansi reset) with NO. (ansi p)($milestone.number)(ansi reset) was closed successfully.'
   set-action-output 'milestone-number' $milestone.number
@@ -257,13 +259,7 @@ export def delete-milestone [
 ] {
   check-gh
   if ($gh_token | is-not-empty) { $env.GH_TOKEN = $gh_token }
-  let milestoneId = if ($milestone | is-int) { $milestone } else {
-    let found = list-milestones $repo | where title == $milestone
-    if ($found | is-empty) {
-      print 'Milestone not found.'; exit $ECODE.INVALID_PARAMETER
-    }
-    $found.0.number
-  }
+  let milestoneId = resolve-milestone-id $repo $milestone
   let result = gh api -X DELETE $'/repos/($repo)/milestones/($milestoneId)'
   let response = $result | from json
   print $'Milestone with NO. (ansi p)($milestoneId)(ansi reset) was deleted successfully.'
@@ -286,6 +282,16 @@ def is-int [] {
   $value =~ '^[0-9]+$'
 }
 
+# Resolve the token used for the direct GraphQL calls. On a runner GH_TOKEN/GITHUB_TOKEN is
+# always set, but locally (`just dr` / `just di`) neither is, and forwarding the resulting null
+# into a `string` positional aborts the run with a type error. Fall back to the gh CLI's own
+# credential so the documented local dry-run workflow keeps working.
+def resolve-gh-token []: nothing -> string {
+  let fromEnv = $env.GH_TOKEN? | default $env.GITHUB_TOKEN? | default ''
+  if ($fromEnv | is-not-empty) { return $fromEnv }
+  do -i { gh auth token | complete } | default {} | get -o stdout | default '' | str trim
+}
+
 def check-gh [] {
   if not (is-installed 'gh') {
     print 'gh command not found, please install it first, see: https://cli.github.com/.'
@@ -298,6 +304,25 @@ def check-gh [] {
 # `--paginate` because a single page only holds 30 milestones.
 def list-milestones [repo: string] {
   gh api -X GET $'/repos/($repo)/milestones' -f state=all --paginate | from json
+}
+
+# Resolve a milestone reference - a number or a title - to its milestone number.
+# Exits with INVALID_PARAMETER when the reference is empty or matches no milestone,
+# so `close` and `delete` report the same diagnostics for the same input.
+def resolve-milestone-id [repo: string, milestone: string]: nothing -> int {
+  if ($milestone | str trim | is-empty) {
+    print $'(ansi r)Error:(ansi reset) A non-empty `milestone` title or number is required.'
+    exit $ECODE.INVALID_PARAMETER
+  }
+  # An all-digit value always wins as a number, so a milestone whose *title* is all digits
+  # can only be addressed by its number. Documented in the README input tables.
+  if ($milestone | is-int) { return ($milestone | into int) }
+  let found = list-milestones $repo | where title == $milestone
+  if ($found | is-empty) {
+    print $'(ansi r)Error:(ansi reset) Milestone (ansi p)($milestone)(ansi reset) not found in repository (ansi p)($repo)(ansi reset).'
+    exit $ECODE.INVALID_PARAMETER
+  }
+  $found.0.number
 }
 
 # Get milestone number by title using REST API
@@ -342,7 +367,7 @@ export def milestone-action [
   action: string,               # Action to perform, could be create, close, or bind-pr.
   repo: string,                 # Github repository name
   --gh-token(-t): string,       # Github access token
-  --milestone(-m): string,      # Milestone name
+  --milestone(-m): string = '', # Milestone title or number
   --title: string = '',         # Milestone title to create
   --due-on(-d): string,         # Milestone due date, format: yyyy-mm-dd
   --description(-D): string,    # Milestone description
@@ -358,7 +383,10 @@ export def milestone-action [
     create => { create-milestone $repo $title --due-on $due_on -D $description -t $gh_token },
     bind-pr => { milestone-bind-for-pr $repo -t $gh_token -m $milestone --pr $pr --force=$force --dry-run=$dry_run --inherit-from-issue=$inherit_from_issue },
     bind-issue => { milestone-bind-for-issue $repo -t $gh_token -m $milestone --issue ($issue | into int) --force=$force --dry-run=$dry_run },
-    _ => { error make { msg: $'Invalid action: ($action)' } },
+    _ => {
+      print $'(ansi r)Error:(ansi reset) Invalid action (ansi p)($action)(ansi reset), should be one of bind-pr, bind-issue, create, close or delete.'
+      exit $ECODE.INVALID_PARAMETER
+    },
   }
 }
 

--- a/nu/query.nu
+++ b/nu/query.nu
@@ -38,8 +38,8 @@ export def query-issue-closer-by-graphql [
 
 # Abort with the actual GraphQL diagnostics instead of letting a missing `data`
 # field surface later as an inscrutable column-not-found error.
-def check-graphql-errors [response: any] {
-  let errors = $response | get -o errors
+def check-graphql-errors []: record -> nothing {
+  let errors = $in | get -o errors
   if ($errors | is-not-empty) {
     print $'(ansi r)GraphQL Error:(ansi reset)'
     $errors | table -e | print
@@ -67,7 +67,7 @@ def query-issue-status [issueNO: int, payload: string, token: string] {
     if $milestone != '-' or $tries > 5 { break }
     print $'Try to query milestone for issue (ansi p)($issueNO)(ansi reset) the (ansi p)($tries)(ansi reset) (if $tries == 1 { "time" } else { "times" }) ...'
     let response = http post --content-type application/json -H $HEADERS $QUERY_API $payload
-    check-graphql-errors $response
+    $response | check-graphql-errors
     $result = ($response | get data.repository.issueOrPullRequest)
 
     $events = $result.timeline.edges.node | where {|it| $it.stateReason? | is-not-empty }
@@ -107,7 +107,7 @@ export def query-pr-closing-issues [
 
   let response = http post --content-type application/json -H $HEADERS $QUERY_API $payload
 
-  check-graphql-errors $response
+  $response | check-graphql-errors
 
   let result = $response | get data.repository.pullRequest
 


### PR DESCRIPTION
Follow-up to the #168/#170/#172/#174 review. `create` could not produce a purely numeric title, `force: yes` aborted with a raw Nushell error, and several paths only reachable outside Actions failed with type errors.

- milestone.nu: use `gh api -f` (raw-field) instead of `-F` for `title`, `description`, `due_on` and `state`; `-F` applies magic type conversion, so `title: '20260821'` was sent as a JSON number and rejected with `422 ... 20260821 is not a string`
- common.nu: add `parse-bool`, accepting true/yes/on/1 and false/no/off/0 and falling back to each input's documented default when empty; replaces the `into bool` call that aborted on `force: yes`
- milestone.nu: extract `resolve-milestone-id`, replacing the two verbatim lookup blocks in `close-milestone`/`delete-milestone`, and report an empty or unmatched milestone with `INVALID_PARAMETER`
- milestone.nu: default `--milestone` to `''` so `close`/`delete` without it report a message instead of `can't convert nothing to string`
- milestone.nu: add `resolve-gh-token`, falling back to the gh CLI's own credential so `just dr` / `just di` work without an exported GH_TOKEN
- milestone.nu: exit with `INVALID_PARAMETER` on an unknown action, and drop the `-d` short flag from `--dry-run`, which means `--due-on` on `milestone-action`
- milestone.nu: move the "PATCH overwrites" comment below the no-milestone guard, where it is actually true, and say so when `--force` has no replacement to apply rather than doing nothing silently
- query.nu: give `check-graphql-errors` typed pipeline input
- ci.yml: cover numeric titles and closing an already-closed milestone; compute the due date in bash so the second Nu version pin is gone
- create/close/delete.yml: run `uses: ./` behind a checkout, so a dispatch exercises the branch it came from instead of `@develop`
- Document that an all-digit `milestone` is always read as a number]

Closes #175 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Numeric milestone values are interpreted as milestone numbers for closing and deleting.
  * Added flexible boolean input validation with clear errors for invalid values.
  * Improved milestone reference resolution and issue-binding behavior.

* **Bug Fixes**
  * Avoided unnecessary milestone overwrites.
  * Preserved existing issue milestones when inference fails.
  * Safely handled attempts to close already-closed milestones.

* **Documentation**
  * Clarified milestone matching, numbering, overwrite behavior, and boolean inputs in English and Chinese documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->